### PR TITLE
Exclude venv and other directories from linters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,9 +26,12 @@ dev = isort>=5.0; flake8; pytest; mypy; pytest
 [flake8]
 max-line-length = 88
 ignore = E203
+exclude =
+    .venv
 
 [mypy]
 ignore_missing_imports = true
 
 [isort]
 profile = black
+skip_glob = [".venv"]


### PR DESCRIPTION
Fixes #9.