### PR TITLE
Support global config as a fallback

### DIFF
--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -15,7 +15,7 @@ if os.name == "nt":
 elif "XDG_CONFIG_HOME" in os.environ:
     GLOBAL_CONFIG = Path(os.environ["XDG_CONFIG_HOME"]) / "black"
 else:
-    GLOBAL_CONFIG = Path.home() / ".config/black"
+    GLOBAL_CONFIG = Path.home() / ".config" / "black"
 
 
 @hookimpl(tryfirst=True)

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 import black
 import toml
@@ -9,13 +9,16 @@ from pylsp import hookimpl
 
 logger = logging.getLogger(__name__)
 
-GLOBAL_CONFIG: Path
-if os.name == "nt":
-    GLOBAL_CONFIG = Path.home() / ".black"
-elif "XDG_CONFIG_HOME" in os.environ:
-    GLOBAL_CONFIG = Path(os.environ["XDG_CONFIG_HOME"]) / "black"
-else:
-    GLOBAL_CONFIG = Path.home() / ".config" / "black"
+GLOBAL_CONFIG: Optional[Path] = None
+try:
+    if os.name == "nt":
+        GLOBAL_CONFIG = Path.home() / ".black"
+    elif "XDG_CONFIG_HOME" in os.environ:
+        GLOBAL_CONFIG = Path(os.environ["XDG_CONFIG_HOME"]) / "black"
+    else:
+        GLOBAL_CONFIG = Path.home() / ".config" / "black"
+except Exception as e:
+    logger.error("Error determining black global config file path: %s", e)
 
 
 @hookimpl(tryfirst=True)
@@ -92,7 +95,7 @@ def load_config(filename: str) -> Dict:
     pyproject_filename = root / "pyproject.toml"
 
     if not pyproject_filename.is_file():
-        if GLOBAL_CONFIG.exists():
+        if GLOBAL_CONFIG is not None and GLOBAL_CONFIG.exists():
             pyproject_filename = GLOBAL_CONFIG
             logger.info("Using global black config at %s", pyproject_filename)
         else:

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -1,8 +1,18 @@
+import os
+from pathlib import Path
 from typing import Dict
 
 import black
 import toml
 from pylsp import hookimpl
+
+GLOBAL_CONFIG: Path
+if os.name == "nt":
+    GLOBAL_CONFIG = Path.home() / ".black"
+elif "XDG_CONFIG_HOME" in os.environ:
+    GLOBAL_CONFIG = Path(os.environ["XDG_CONFIG_HOME"]) / "black"
+else:
+    GLOBAL_CONFIG = Path.home() / ".config/black"
 
 
 @hookimpl(tryfirst=True)
@@ -74,7 +84,10 @@ def load_config(filename: str) -> Dict:
     pyproject_filename = root / "pyproject.toml"
 
     if not pyproject_filename.is_file():
-        return defaults
+        if GLOBAL_CONFIG.exists():
+            pyproject_filename = GLOBAL_CONFIG
+        else:
+            return defaults
 
     try:
         pyproject_toml = toml.load(str(pyproject_filename))

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -19,6 +19,9 @@ try:
         GLOBAL_CONFIG = Path.home() / ".config" / "black"
 except Exception as e:
     logger.error("Error determining black global config file path: %s", e)
+else:
+    if GLOBAL_CONFIG is not None and GLOBAL_CONFIG.exists():
+        logger.info("Found black global config file at %s", GLOBAL_CONFIG)
 
 
 @hookimpl(tryfirst=True)


### PR DESCRIPTION
Based on the [black docs](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#where-black-looks-for-the-file) black will fall back to a global settings file if there is not a project scoped file.  This just supports the same behavior in this plugin.