### PR TITLE
Log black errors to stderr

### DIFF
--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -82,14 +82,14 @@ def load_config(filename: str) -> Dict:
     pyproject_filename = root / "pyproject.toml"
 
     if not pyproject_filename.is_file():
-        logger.info("Using defaults for python-lsp-black: %r", defaults)
+        logger.info("Using defaults: %r", defaults)
         return defaults
 
     try:
         pyproject_toml = toml.load(str(pyproject_filename))
     except (toml.TomlDecodeError, OSError):
-        logger.info(
-            "Error decoding pyproject.toml, using defaults for python-lsp-black: %r",
+        logger.warning(
+            "Error decoding pyproject.toml, using defaults: %r",
             defaults,
         )
         return defaults
@@ -121,8 +121,6 @@ def load_config(filename: str) -> Dict:
 
     config["target_version"] = target_version
 
-    logger.info(
-        "Using config from %s for python-lsp-black: %r", pyproject_filename, config
-    )
+    logger.info("Using config from %s: %r", pyproject_filename, config)
 
     return config

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -89,7 +89,7 @@ def load_config(filename: str) -> Dict:
         pyproject_toml = toml.load(str(pyproject_filename))
     except (toml.TomlDecodeError, OSError):
         logger.info(
-            "Error decoding pyproject.toml file, using defaults for python-lsp-black: %r",
+            "Error decoding pyproject.toml, using defaults for python-lsp-black: %r",
             defaults,
         )
         return defaults

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -65,7 +65,7 @@ def format_text(*, text, config):
     ) as e:
         # errors will show on lsp stderr stream
         logger.error("Error formatting with black: %s", e)
-        raise black.NothingChanged
+        raise black.NothingChanged from e
 
 
 def load_config(filename: str) -> Dict:

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -64,7 +64,7 @@ def format_text(*, text, config):
     except black.NothingChanged:
         raise
     except Exception as e:
-        logger.exception("Error formatting with black: %s", e)
+        logger.error("Error formatting with black: %s", e.message)
         raise black.NothingChanged
 
 


### PR DESCRIPTION
Previously errors were being silently dropped.

INFO log messages don't seem to be displayed by [python-lsp-server](https://github.com/python-lsp/python-lsp-server/) for now, at least not in its default configuration, but they don't hurt.

Fixes #20.