### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,13 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: python -m pip install -e .[dev]
-    - name: Flake8 lint
-      run: flake8 .
-    - name: Black lint
-      run: black --diff --check .
-    - name: isort lint
-      run: isort --check --diff .
-    - name: MyPy lint
-      run: mypy .
-    - name: Test
+    - name: pre-commit checks
+      uses: pre-commit/action@v2.0.2
+    - name: Tests
       run: pytest -v tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,3 @@ repos:
   hooks:
   - id: check-merge-conflict
   - id: debug-statements
-- repo: https://github.com/executablebooks/mdformat
-  rev: 0.7.10
-  hooks:
-  - id: mdformat
-    additional_dependencies:
-    - mdformat-gfm

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+- repo: https://github.com/PyCQA/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+- repo: https://github.com/psf/black
+  rev: 21.11b1
+  hooks:
+  - id: black
+    exclude: fixtures
+    args: [--check, --config=pyproject.toml]
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.910-1
+  hooks:
+  - id: mypy
+    additional_dependencies: [black, types-pkg_resources, types-setuptools, types-toml]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+  - id: check-merge-conflict
+  - id: debug-statements
+- repo: https://github.com/executablebooks/mdformat
+  rev: 0.7.10
+  hooks:
+  - id: mdformat
+    additional_dependencies:
+    - mdformat-gfm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ### Issues Closed
 
-* [Issue 3](https://github.com/python-lsp/python-lsp-black/issues/3) - Update README and add RELEASE instructions
-* [Issue 2](https://github.com/python-lsp/python-lsp-black/issues/2) - Release v1.0.0
+- [Issue 3](https://github.com/python-lsp/python-lsp-black/issues/3) - Update README and add RELEASE instructions
+- [Issue 2](https://github.com/python-lsp/python-lsp-black/issues/2) - Release v1.0.0
 
 In this release 2 issues were closed.
 
 ### Pull Requests Merged
 
-* [PR 1](https://github.com/python-lsp/python-lsp-black/pull/1) - PR: Python LSP server migration, by [@andfoy](https://github.com/andfoy)
+- [PR 1](https://github.com/python-lsp/python-lsp-black/pull/1) - PR: Python LSP server migration, by [@andfoy](https://github.com/andfoy)
 
 In this release 1 pull request was closed.

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,7 +1,8 @@
 The following are instructions to maintain python-lsp-black
+
 1. Releases are tracked using Github milestones, which can be created and closed
-under the `Issues > Milestones` page: https://github.com/python-lsp/python-lsp-black/milestones.
-2. If a issue will be fixed as part of a particular release, then its milestone
-should be the release-corresponding one.
-3. Please make sure that PRs are also tracked under a specific milestone.
-4. Please follow the [RELEASE.md](./RELEASE.md) file when making a release.
+   under the `Issues > Milestones` page: https://github.com/python-lsp/python-lsp-black/milestones.
+1. If a issue will be fixed as part of a particular release, then its milestone
+   should be the release-corresponding one.
+1. Please make sure that PRs are also tracked under a specific milestone.
+1. Please follow the [RELEASE.md](./RELEASE.md) file when making a release.

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ flake8:
 isort:
 	pre-commit run -a isort
 
-markdown:
-	pre-commit run -a mdformat
-
 mypy:
 	pre-commit run -a mypy
 

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,20 @@
-lint: flake8 black-check isort-check mypy
-
-flake8:
-	flake8 .
+lint:
+	pre-commit run -a
 
 black:
-	black .
+	pre-commit run -a black
 
-black-check:
-	black --diff --check .
+flake8:
+	pre-commit run -a flake8
 
 isort:
-	isort .
+	pre-commit run -a isort
 
-isort-check:
-	isort --check-only .
+markdown:
+	pre-commit run -a mdformat
 
 mypy:
-	mypy .
+	pre-commit run -a mypy
 
 test:
 	pytest -v .

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To run linters:
 
 ```shell
 make lint  # just a shortcut to pre-commit run -a
-make <linter_name>  # black, flake8, isort, markdown, mypy
+make <linter_name>  # black, flake8, isort, mypy
 ```
 
 To upgrade the version of the pre-commit hooks:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![PyPI](https://img.shields.io/pypi/v/pyls-black.svg)](https://pypi.org/project/python-lsp-black) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 [![Python](https://github.com/python-lsp/python-lsp-black/actions/workflows/python.yml/badge.svg)](https://github.com/python-lsp/python-lsp-black/actions/workflows/python.yml)
 
-
 > [Black](https://github.com/ambv/black) plugin for the [Python LSP Server](https://github.com/python-lsp/python-lsp-server).
 
 ## Install
@@ -18,11 +17,11 @@ pip install python-lsp-black
 
 To avoid unexpected results you should make sure `yapf` and `autopep8` are not installed.
 
-* `python-lsp-black` can either format an entire file or just the selected text.
-* The code will only be formatted if it is syntactically valid Python.
-* Text selections are treated as if they were a separate Python file.
+- `python-lsp-black` can either format an entire file or just the selected text.
+- The code will only be formatted if it is syntactically valid Python.
+- Text selections are treated as if they were a separate Python file.
   Unfortunately this means you can't format an indented block of code.
-* `python-lsp-black` will use your project's [pyproject.toml](https://github.com/ambv/black#pyprojecttoml) if it has one.
+- `python-lsp-black` will use your project's [pyproject.toml](https://github.com/ambv/black#pyprojecttoml) if it has one.
 
 # Development
 
@@ -34,14 +33,30 @@ python -m venv .venv
 pip install -e .[dev]
 ```
 
+This project uses [pre-commit](https://pre-commit.com/) hooks to control code quality,
+install them to run them when creating a git commit, thus avoiding seeing errors when you
+create a pull request:
+
+```shell
+pre-commit install
+```
+
 To run tests:
 
 ```shell
 make test
 ```
 
-To run linters (flake8, black, isort, mypy...)
+To run linters:
 
 ```shell
-make lint
+make lint  # just a shortcut to pre-commit run -a
+make <linter_name>  # black, flake8, isort, markdown, mypy
+```
+
+To upgrade the version of the pre-commit hooks:
+
+```shell
+pre-commit autoupdate
+# check and git commit changes to .pre-commit-config.yaml
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,18 +1,19 @@
 To release a new version of python-lsp-black:
+
 1. git fetch upstream && git checkout upstream/master
-2. Close milestone on GitHub
-3. git clean -xfdi
-4. Update CHANGELOG.md with loghub: `loghub python-lsp/python-lsp-black  --milestone vX.X.X`
-5. git add -A && git commit -m "Update Changelog"
-6. Update release version in ``setup.cfg`` (set release version, remove '.dev0')
-7. git add -A && git commit -m "Release vX.X.X"
-8. python setup.py sdist
-9. python setup.py bdist_wheel
-10. twine check dist/*
-11. twine upload dist/*
-12. git tag -a vX.X.X -m "Release vX.X.X"
-13. Update development version in ``setup.cfg`` (add '.dev0' and increment minor)
-14. git add -A && git commit -m "Back to work"
-15. git push upstream master
-16. git push upstream --tags
-17. Draft a new release in GitHub using the new tag.
+1. Close milestone on GitHub
+1. git clean -xfdi
+1. Update CHANGELOG.md with loghub: `loghub python-lsp/python-lsp-black  --milestone vX.X.X`
+1. git add -A && git commit -m "Update Changelog"
+1. Update release version in `setup.cfg` (set release version, remove '.dev0')
+1. git add -A && git commit -m "Release vX.X.X"
+1. python setup.py sdist
+1. python setup.py bdist_wheel
+1. twine check dist/\*
+1. twine upload dist/\*
+1. git tag -a vX.X.X -m "Release vX.X.X"
+1. Update development version in `setup.cfg` (add '.dev0' and increment minor)
+1. git add -A && git commit -m "Back to work"
+1. git push upstream master
+1. git push upstream --tags
+1. Draft a new release in GitHub using the new tag.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ python_requires = >= 3.6
 pylsp = pylsp_black = pylsp_black.plugin
 
 [options.extras_require]
-dev = isort>=5.0; flake8; pytest; mypy; pytest; types-pkg_resources; types-toml
+# add any types-* packages to .pre-commit-config.yaml mypy additional_dependencies
+dev = isort>=5.0; flake8; pre-commit; pytest; mypy; pytest; types-pkg_resources; types-setuptools; types-toml
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
This introduces [pre-commit](https://pre-commit.com/) to replace the manual lint checks. Developers are encouraged to install the pre-commit hooks to catch errors ahead of time.