### PR TITLE
Add client side configuration and cache configuration per file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .mypy_cache
 *.egg-info
 *.pyc
+*.orig
 .pytest_cache
 .ropeproject
 build

--- a/README.md
+++ b/README.md
@@ -21,8 +21,31 @@ To avoid unexpected results you should make sure `yapf` and `autopep8` are not i
 - The code will only be formatted if it is syntactically valid Python.
 - Text selections are treated as if they were a separate Python file.
   Unfortunately this means you can't format an indented block of code.
-- `python-lsp-black` will use your project's [pyproject.toml](https://github.com/psf/black#pyprojecttoml) if it has one.
-- `python-lsp-black` only officially supports the latest stable version of [black](https://github.com/psf/black). An effort is made to keep backwards-compatibility but older black versions will not be actively tested.
+- `python-lsp-black` will use your project's
+  [pyproject.toml](https://github.com/psf/black#pyprojecttoml) if it has one.
+- `python-lsp-black` only officially supports the latest stable version of
+  [black](https://github.com/psf/black). An effort is made to keep backwards-compatibility
+  but older black versions will not be actively tested.
+- The plugin can cache the black configuration that applies to each Python file, this
+  improves performance of the plugin. When configuration caching is enabled any changes to
+  black's configuration will need the LSP server to be restarted. Configuration caching
+  can be disabled with the `cache_config` option, see *Configuration* below.
+
+# Configuration
+
+The plugin follows [python-lsp-server's
+configuration](https://github.com/python-lsp/python-lsp-server/#configuration=). These are
+the valid configuration keys:
+
+- `pylsp.plugins.black.enabled`: boolean to enable/disable the plugin.
+- `pylsp.plugins.black.cache_config`: a boolean to enable black configuration caching (see
+  *Usage*). `false` by default.
+- `pylsp.plugins.black.line_length`: an integer that maps to [black's
+  `max-line-length`](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length)
+  setting. Defaults to 88 (same as black's default). This can also be set through black's
+  configuration files, which should be preferred for multi-user projects.
+- `pylsp.plugins.black.preview`: a boolean to enable or disable [black's `--preview`
+  setting](https://black.readthedocs.io/en/stable/the_black_code_style/future_style.html#preview-style).
 
 # Development
 
@@ -35,8 +58,8 @@ pip install -e .[dev]
 ```
 
 This project uses [pre-commit](https://pre-commit.com/) hooks to control code quality,
-install them to run them when creating a git commit, thus avoiding seeing errors when you
-create a pull request:
+install them to run automatically when creating a git commit, thus avoiding seeing errors
+when you create a pull request:
 
 ```shell
 pre-commit install

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To avoid unexpected results you should make sure `yapf` and `autopep8` are not i
 # Configuration
 
 The plugin follows [python-lsp-server's
-configuration](https://github.com/python-lsp/python-lsp-server/#configuration=). These are
+configuration](https://github.com/python-lsp/python-lsp-server/#configuration). These are
 the valid configuration keys:
 
 - `pylsp.plugins.black.enabled`: boolean to enable/disable the plugin.

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -106,7 +106,7 @@ def format_text(*, text, config):
 
 
 @lru_cache(100)
-def load_config(filename: str, client_config: Config) -> Dict:
+def _load_config(filename: str, client_config: Config) -> Dict:
     settings = client_config.plugin_settings("black")
 
     defaults = {
@@ -173,3 +173,13 @@ def load_config(filename: str, client_config: Config) -> Dict:
     logger.info("Using config from %s: %r", pyproject_filename, config)
 
     return config
+
+
+def load_config(filename: str, client_config: Config) -> Dict:
+    settings = client_config.plugin_settings("black")
+
+    # Use the original, not cached function to load settings if requested
+    if not settings.get("cache_config", True):
+        return _load_config.__wrapped__(filename, client_config)
+
+    return _load_config(filename, client_config)

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -41,6 +41,22 @@ def pylsp_format_range(config, document, range):
     return format_document(config, document, range)
 
 
+@hookimpl
+def pylsp_settings():
+    """Configuration options that can be set on the client."""
+    return {
+        "plugins": {
+            "black": {
+                # Disable this plugin by default because it's third-party.
+                "enabled": False,
+                "line_length": 88,
+                "preview": False,
+                "cache_config": False,
+            }
+        }
+    }
+
+
 def format_document(client_config, document, range=None):
     if range:
         start = range["start"]["line"]

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -180,7 +180,7 @@ def load_config(filename: str, client_config: Config) -> Dict:
     settings = client_config.plugin_settings("black")
 
     # Use the original, not cached function to load settings if requested
-    if not settings.get("cache_config", True):
+    if not settings.get("cache_config", False):
         return _load_config.__wrapped__(filename, client_config)
 
     return _load_config(filename, client_config)

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -115,6 +115,7 @@ def _load_config(filename: str, client_config: Config) -> Dict:
         "pyi": filename.endswith(".pyi"),
         "skip_string_normalization": False,
         "target_version": set(),
+        "preview": settings.get("preview", False),
     }
 
     root = black.find_project_root((filename,))

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -47,8 +47,7 @@ def pylsp_settings():
     return {
         "plugins": {
             "black": {
-                # Disable this plugin by default because it's third-party.
-                "enabled": False,
+                "enabled": True,
                 "line_length": 88,
                 "preview": False,
                 "cache_config": False,

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -103,6 +104,7 @@ def format_text(*, text, config):
         raise black.NothingChanged from e
 
 
+@lru_cache(100)
 def load_config(filename: str) -> Dict:
     defaults = {
         "line_length": 88,

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 
 [options]
 packages = find:
-install_requires = python-lsp-server>=1.4.0; black>=19.3b0; toml
+install_requires = python-lsp-server>=1.4.0; black>=22.1.0; toml
 python_requires = >= 3.7
 
 [options.entry_points]

--- a/tests/fixtures/formatted-line-length.py
+++ b/tests/fixtures/formatted-line-length.py
@@ -1,0 +1,4 @@
+def foo(
+    aaaaa, bbbbb, ccccc, ddddd, eeeee, fffff, ggggg, hhhhh, iiiii, jjjjj, kkkkk
+):
+    return aaaaa  # noqa

--- a/tests/fixtures/unformatted-line-length.py
+++ b/tests/fixtures/unformatted-line-length.py
@@ -1,0 +1,3 @@
+
+def foo(aaaaa, bbbbb, ccccc, ddddd, eeeee, fffff, ggggg, hhhhh, iiiii, jjjjj, kkkkk):
+    return aaaaa  # noqa

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -36,7 +36,7 @@ def config(workspace):
     """Return a config object."""
     cfg = Config(workspace.root_uri, {}, 0, {})
     cfg._plugin_settings = {
-        "plugins": {"black": {"line_length": 88, "cache_config": True}}
+        "plugins": {"black": {"line_length": 88, "cache_config": False}}
     }
     return cfg
 
@@ -313,16 +313,15 @@ def test_pylsp_format_line_length(
 
 
 def test_cache_config(config, unformatted_document):
-    # Cache should be working by default
-    for _ in range(5):
-        pylsp_format_document(config, unformatted_document)
-    assert _load_config.cache_info().hits == 4
-
-    # Clear cache and disable it
-    _load_config.cache_clear()
-    config.update({"plugins": {"black": {"cache_config": False}}})
-
-    # Cache should not be working now
+    # Cache should be off by default
     for _ in range(5):
         pylsp_format_document(config, unformatted_document)
     assert _load_config.cache_info().hits == 0
+
+    # Enable cache
+    config.update({"plugins": {"black": {"cache_config": True}}})
+
+    # Cache should be working now
+    for _ in range(5):
+        pylsp_format_document(config, unformatted_document)
+    assert _load_config.cache_info().hits == 4

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -234,6 +234,7 @@ def test_load_config(config):
         "pyi": True,
         "fast": True,
         "skip_string_normalization": True,
+        "preview": False,
     }
 
 
@@ -264,6 +265,7 @@ def test_load_config_defaults(config):
         "pyi": False,
         "fast": False,
         "skip_string_normalization": False,
+        "preview": False,
     }
 
 


### PR DESCRIPTION
Use `lru_cache` decorator on `load_config` to remember the black configuration for each file that the plugin processes. If the black configuration changes for any reason (e.g. the user editing the *pyproject.toml* file for the project) then the LSP server would need to be restarted for *python-lsp-black* to refresh the configuration.

- [x] Support plugin configuration (`pylsp.plugins.black` namespace)
- [x] Add unit test for plugin configuration.
- [x] Only enable `load_config` caching if `pylsp.plugins.black.cache_config` is set in plugin settings.
- [x] Add unit test for config caching.
- [x] Support Black's preview features if `pylsp.plugins.black.preview` is `true`.