### PR TITLE
Fix TypeError when formatting with black 22.1.0+

### DIFF
--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -95,7 +95,11 @@ def load_config(filename: str) -> Dict:
 
     root = black.find_project_root((filename,))
 
-    pyproject_filename = root / "pyproject.toml"
+    # Black 22.1.0+ returns a tuple
+    if isinstance(root, tuple):
+        pyproject_filename = root[0] / "pyproject.toml"
+    else:
+        pyproject_filename = root / "pyproject.toml"
 
     if not pyproject_filename.is_file():
         if GLOBAL_CONFIG is not None and GLOBAL_CONFIG.exists():

--- a/tests/fixtures/target_version/pyproject.toml
+++ b/tests/fixtures/target_version/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-target-version = ['py27']
+target-version = ['py39']

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -190,7 +190,7 @@ def test_load_config():
 def test_load_config_target_version():
     config = load_config(str(fixtures_dir / "target_version" / "example.py"))
 
-    assert config["target_version"] == {black.TargetVersion.PY27}
+    assert config["target_version"] == {black.TargetVersion.PY39}
 
 
 def test_load_config_py36():


### PR DESCRIPTION
Resolve an TypeError issue caused by the return type of `find_project_root` changing in black 22.1.0.

Closes #29 