### PR TITLE
Change entrypoint name to simply be `black`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires = python-lsp-server>=1.4.0; black>=22.3.0; toml
 python_requires = >= 3.7
 
 [options.entry_points]
-pylsp = pylsp_black = pylsp_black.plugin
+pylsp = black = pylsp_black.plugin
 
 [options.extras_require]
 # add any types-* packages to .pre-commit-config.yaml mypy additional_dependencies

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -19,6 +19,7 @@ from pylsp_black.plugin import (
     load_config,
     pylsp_format_document,
     pylsp_format_range,
+    pylsp_settings,
 )
 
 here = Path(__file__).parent
@@ -273,7 +274,7 @@ def test_load_config_defaults(config):
 
 def test_entry_point():
     distribution = pkg_resources.get_distribution("python-lsp-black")
-    entry_point = distribution.get_entry_info("pylsp", "pylsp_black")
+    entry_point = distribution.get_entry_info("pylsp", "black")
 
     assert entry_point is not None
 
@@ -327,3 +328,13 @@ def test_cache_config(config, unformatted_document):
     for _ in range(5):
         pylsp_format_document(config, unformatted_document)
     assert _load_config.cache_info().hits == 4
+
+
+def test_pylsp_settings(config):
+    plugins = dict(config.plugin_manager.list_name_plugin())
+    assert "black" in plugins
+    assert plugins["black"] not in config.disabled_plugins
+    config.update({"plugins": {"black": {"enabled": False}}})
+    assert plugins["black"] in config.disabled_plugins
+    config.update(pylsp_settings())
+    assert plugins["black"] not in config.disabled_plugins


### PR DESCRIPTION
This PR renames the entrypoint name `pylsp_black` to `black`.

Currently, `pylsp.plugins.black.enabled: false` cannot disable the plugin because `pluggy.PluginManager` used in [`pylsp.config.config.Config`](https://github.com/python-lsp/python-lsp-server/blob/v1.7.0/pylsp/config/config.py#L78) registers a plugin using its entrypoint name [[link](https://github.com/pytest-dev/pluggy/blob/1.0.0/src/pluggy/_manager.py#L288)].
Thus, the plugin is registered as `pylsp_black` and can be disabled by `pylsp.plugins.pylsp_black.enabled: false`.
This is confusing because we have to use `pylsp.plugins.pylsp_black.enabled` when disabling the plugin while using `pylsp.plugins.black.*` to give settings to black.
This issue does not occur in [python-lsp-ruff](https://github.com/python-lsp/python-lsp-ruff) because it uses `ruff` as its entrypoint name [[link](https://github.com/python-lsp/python-lsp-ruff/blob/v1.0.5/pyproject.toml#L24)].

Fixes #41.