### PR TITLE
pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,25 @@
 repos:
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 23.3.0
   hooks:
   - id: black
     exclude: fixtures
     args: [--check, --config=pyproject.toml]
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/PyCQA/flake8
+  rev: 6.0.0
   hooks:
   - id: flake8
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.942
+  rev: v1.3.0
   hooks:
   - id: mypy
     additional_dependencies: [black, types-pkg_resources, types-setuptools, types-toml]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.4.0
   hooks:
   - id: check-merge-conflict
   - id: debug-statements


### PR DESCRIPTION
```
$ pre-commit autoupdate
[https://github.com/PyCQA/isort] updating 5.10.1 -> 5.12.0
[https://github.com/psf/black] updating 22.3.0 -> 23.3.0
[https://github.com/PyCQA/flake8] updating 3.9.2 -> 6.0.0
[https://github.com/pre-commit/mirrors-mypy] updating v0.942 -> v1.3.0
[https://github.com/pre-commit/pre-commit-hooks] updating v4.1.0 -> v4.4.0
```