### PR TITLE
Read skip options from plugin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ the valid configuration keys:
   configuration files, which should be preferred for multi-user projects.
 - `pylsp.plugins.black.preview`: a boolean to enable or disable [black's `--preview`
   setting](https://black.readthedocs.io/en/stable/the_black_code_style/future_style.html#preview-style).
+- `pylsp.plugins.black.skip_string_normalization`: a boolean to enable or disable black's `--skip-string-normalization` setting. `false` by default.
+- `pylsp.plugins.black.skip_magic_trailing_comma`: a boolean to enable or disable black's `skip-magic-trailing-comma` setting. `false` by default.
 
 # Development
 

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -137,8 +137,8 @@ def _load_config(filename: str, client_config: Config) -> Dict:
         "line_length": settings.get("line_length", 88),
         "fast": False,
         "pyi": filename.endswith(".pyi"),
-        "skip_string_normalization": False,
-        "skip_magic_trailing_comma": False,
+        "skip_string_normalization": settings.get("skip_string_normalization", False),
+        "skip_magic_trailing_comma": settings.get("skip_magic_trailing_comma", False),
         "target_version": set(),
         "preview": settings.get("preview", False),
     }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -42,6 +42,23 @@ def config(workspace):
 
 
 @pytest.fixture
+def config_with_skip_options(workspace):
+    """Return a config object."""
+    cfg = Config(workspace.root_uri, {}, 0, {})
+    cfg._plugin_settings = {
+        "plugins": {
+            "black": {
+                "line_length": 88,
+                "cache_config": False,
+                "skip_string_normalization": True,
+                "skip_magic_trailing_comma": True,
+            }
+        }
+    }
+    return cfg
+
+
+@pytest.fixture
 def unformatted_document(workspace):
     path = fixtures_dir / "unformatted.txt"
     uri = f"file:/{path}"
@@ -267,6 +284,22 @@ def test_load_config_defaults(config):
         "fast": False,
         "skip_magic_trailing_comma": False,
         "skip_string_normalization": False,
+        "preview": False,
+    }
+
+
+def test_load_config_with_skip_options(config_with_skip_options):
+    config = load_config(
+        str(fixtures_dir / "skip_options" / "example.py"), config_with_skip_options
+    )
+
+    assert config == {
+        "line_length": 88,
+        "target_version": set(),
+        "pyi": False,
+        "fast": False,
+        "skip_magic_trailing_comma": True,
+        "skip_string_normalization": True,
         "preview": False,
     }
 


### PR DESCRIPTION
`skip_*` options are set to `False` by default and plugin settings are ignored for these two options.

An alternative would be to accept all `black.FileMode` arguments as settings and pass as is.