### PR TITLE
Use new `lines` option in Black 23.11 to format range

### DIFF
--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -66,6 +66,7 @@ def pylsp_settings():
 def format_document(client_config, document, range=None):
     text = document.source
     config = load_config(document.path, client_config)
+    # Black lines indices are "1-based and inclusive on both ends"
     lines = [(range["start"]["line"] + 1, range["end"]["line"])] if range else ()
 
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 packages = find:
 install_requires =
     python-lsp-server>=1.4.0
-    black>=22.3.0
+    black>=23.11.0
     tomli; python_version<'3.11'
 python_requires = >= 3.7
 

--- a/tests/fixtures/formatted.txt
+++ b/tests/fixtures/formatted.txt
@@ -1,2 +1,15 @@
 a = "hello"
-b = 42
+b = [
+    "a",
+    "very",
+    "very",
+    "very",
+    "very",
+    "very",
+    "very",
+    "very",
+    "very",
+    "long",
+    "line",
+]
+c = 42

--- a/tests/fixtures/unformatted.txt
+++ b/tests/fixtures/unformatted.txt
@@ -1,2 +1,3 @@
 a = 'hello'
-b =  42
+b = ["a", "very", "very", "very", "very", "very", "very", "very", "very", "long", "line"]
+c =  42

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -139,7 +139,7 @@ def test_pylsp_format_document(config, unformatted_document, formatted_document)
         {
             "range": {
                 "start": {"line": 0, "character": 0},
-                "end": {"line": 2, "character": 0},
+                "end": {"line": 3, "character": 0},
             },
             "newText": formatted_document.source,
         }
@@ -204,7 +204,20 @@ def test_pylsp_format_document_with_config(config, config_document):
 
 @pytest.mark.parametrize(
     ("start", "end", "expected"),
-    [(0, 0, 'a = "hello"\n'), (1, 1, "b = 42\n"), (0, 1, 'a = "hello"\nb = 42\n')],
+    [
+        (0, 0, 'a = "hello"\n'),
+        (
+            1,
+            1,
+            'b = [\n    "a",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "long",\n    "line",\n]\n',
+        ),
+        (2, 2, "c = 42\n"),
+        (
+            0,
+            2,
+            'a = "hello"\nb = [\n    "a",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "long",\n    "line",\n]\nc = 42\n',
+        ),
+    ],
 )
 def test_pylsp_format_range(config, unformatted_document, start, end, expected):
     range = {

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -209,13 +209,13 @@ def test_pylsp_format_document_with_config(config, config_document):
         (
             1,
             1,
-            'b = [\n    "a",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "long",\n    "line",\n]\n',
+            'b = [\n    "a",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "long",\n    "line",\n]\n',  # noqa: E501
         ),
         (2, 2, "c = 42\n"),
         (
             0,
             2,
-            'a = "hello"\nb = [\n    "a",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "long",\n    "line",\n]\nc = 42\n',
+            'a = "hello"\nb = [\n    "a",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "very",\n    "long",\n    "line",\n]\nc = 42\n',  # noqa: E501
         ),
     ],
 )


### PR DESCRIPTION
Possible fix for https://github.com/spyder-ide/spyder/issues/21460 where formatting a text selection with black does not work if the code is intended due to black requiring the entire text as input.

This is using the new `lines` option added in black 23.11.0 that allows formatting only a range of lines in the text: https://github.com/psf/black/releases/tag/23.11.0

Doc: 
- https://black.readthedocs.io/en/stable/contributing/reference/reference_functions.html#black.format_file_contents
- https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#line-ranges

Fixes #42