### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -184,14 +184,6 @@ def _load_config(filename: str, client_config: Config) -> Dict:
         target_version = set(
             black.TargetVersion[x.upper()] for x in file_config["target_version"]
         )
-    elif file_config.get("py36"):
-        target_version = {
-            black.TargetVersion.PY36,
-            black.TargetVersion.PY37,
-            black.TargetVersion.PY38,
-            black.TargetVersion.PY39,
-            black.TargetVersion.PY310,
-        }
     else:
         target_version = set()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']
 exclude = '''
 /(
 	  \.venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     python-lsp-server>=1.4.0
     black>=22.3.0
     tomli; python_version<'3.11'
-python_requires = >= 3.7
+python_requires = >= 3.8
 
 [options.entry_points]
 pylsp = pylsp_black = pylsp_black.plugin

--- a/tests/fixtures/py36/pyproject.toml
+++ b/tests/fixtures/py36/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.black]
-py36 = true

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -61,21 +61,21 @@ def config_with_skip_options(workspace):
 @pytest.fixture
 def unformatted_document(workspace):
     path = fixtures_dir / "unformatted.txt"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     return Document(uri, workspace)
 
 
 @pytest.fixture
 def unformatted_pyi_document(workspace):
     path = fixtures_dir / "unformatted.pyi"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     return Document(uri, workspace)
 
 
 @pytest.fixture
 def unformatted_crlf_document(workspace):
     path = fixtures_dir / "unformatted-crlf.py"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     with open(path, "r", newline="") as f:
         source = f.read()
     return Document(uri, workspace, source=source)
@@ -84,21 +84,21 @@ def unformatted_crlf_document(workspace):
 @pytest.fixture
 def formatted_document(workspace):
     path = fixtures_dir / "formatted.txt"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     return Document(uri, workspace)
 
 
 @pytest.fixture
 def formatted_pyi_document(workspace):
     path = fixtures_dir / "formatted.pyi"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     return Document(uri, workspace)
 
 
 @pytest.fixture
 def formatted_crlf_document(workspace):
     path = fixtures_dir / "formatted-crlf.py"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     with open(path, "r", newline="") as f:
         source = f.read()
     return Document(uri, workspace, source=source)
@@ -107,28 +107,28 @@ def formatted_crlf_document(workspace):
 @pytest.fixture
 def invalid_document(workspace):
     path = fixtures_dir / "invalid.txt"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     return Document(uri, workspace)
 
 
 @pytest.fixture
 def config_document(workspace):
     path = fixtures_dir / "config" / "config.txt"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     return Document(uri, workspace)
 
 
 @pytest.fixture
 def unformatted_line_length(workspace):
     path = fixtures_dir / "unformatted-line-length.py"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     return Document(uri, workspace)
 
 
 @pytest.fixture
 def formatted_line_length(workspace):
     path = fixtures_dir / "formatted-line-length.py"
-    uri = f"file:/{path}"
+    uri = f"file:/{path}"  # noqa
     return Document(uri, workspace)
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -262,18 +262,6 @@ def test_load_config_target_version(config):
     assert config["target_version"] == {black.TargetVersion.PY39}
 
 
-def test_load_config_py36(config):
-    config = load_config(str(fixtures_dir / "py36" / "example.py"), config)
-
-    assert config["target_version"] == {
-        black.TargetVersion.PY36,
-        black.TargetVersion.PY37,
-        black.TargetVersion.PY38,
-        black.TargetVersion.PY39,
-        black.TargetVersion.PY310,
-    }
-
-
 def test_load_config_defaults(config):
     config = load_config(str(fixtures_dir / "example.py"), config)
 


### PR DESCRIPTION
Also:

- Drop some tests for Python 3.6.
- Add Python 3.12 to the test matrix.