### PR TITLE
Make tests work with black 24.3.0

### DIFF
--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -127,7 +127,7 @@ def format_text(*, text, config, lines):
         IndentationError,
         # raised when black produces invalid Python code or formats the file
         # differently on the second pass
-        AssertionError,
+        black.parsing.ASTSafetyError,
     ) as e:
         # errors will show on lsp stderr stream
         logger.error("Error formatting with black: %s", e)


### PR DESCRIPTION
Closes: #57

Black changed raising exception from AssertionError to ASTSafetyError and we need to apply similar change.

See: https://github.com/psf/black/commit/6af7d1109693c4ad3af08ecbc34649c232b47a6d