### PR TITLE
Fix compatibility with black≥26.5

### DIFF
--- a/pylsp_black/plugin.py
+++ b/pylsp_black/plugin.py
@@ -100,6 +100,21 @@ def format_text(*, text, config, lines):
         magic_trailing_comma=not config["skip_magic_trailing_comma"],
         preview=config["preview"],
     )
+    handled_errors = (
+        # raised when the file has syntax errors
+        ValueError,
+        # raised when the file being formatted has an indentation error
+        IndentationError,
+        # raised when black produces invalid Python code or formats the file
+        # differently on the second pass
+        black.parsing.ASTSafetyError,
+    )
+    # SourceASTParseError was split out from ASTSafetyError in black 26.5.0,
+    # https://github.com/psf/black/pull/5080; expect it if it exists.
+    try:
+        handled_errors += (black.parsing.SourceASTParseError,)
+    except AttributeError:
+        pass
     try:
         # Black's format_file_contents only works reliably when eols are '\n'. It gives
         # an error for '\r' and produces wrong formatting for '\r\n'. So we replace
@@ -120,15 +135,7 @@ def format_text(*, text, config, lines):
             formatted_text = formatted_text.replace("\n", eol_chars)
 
         return formatted_text
-    except (
-        # raised when the file has syntax errors
-        ValueError,
-        # raised when the file being formatted has an indentation error
-        IndentationError,
-        # raised when black produces invalid Python code or formats the file
-        # differently on the second pass
-        black.parsing.ASTSafetyError,
-    ) as e:
+    except handled_errors as e:
         # errors will show on lsp stderr stream
         logger.error("Error formatting with black: %s", e)
         raise black.NothingChanged from e


### PR DESCRIPTION
The `black.parsing.SourceASTParseError` exception type was split out from `black.parsing.ASTSafetyError` in `black` 26.5.0, https://github.com/psf/black/pull/5080.

This fixes:

```
========================================================================================= FAILURES ==========================================================================================
__________________________________________________________________________ test_pylsp_format_document_syntax_error __________________________________________________________________________

>   ???

src/black/__init__.py:1636:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   SyntaxError: unexpected indent (<unknown>, line 1)

src/black/parsing.py:162: SyntaxError

During handling of the above exception, another exception occurred:

config = <pylsp.config.config.Config object at 0x7ff7e753de00>, invalid_document = <pylsp.workspace.Document object at 0x7ff7e7545f20>

    def test_pylsp_format_document_syntax_error(config, invalid_document):
>       result = pylsp_format_document(config, invalid_document)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/test_plugin.py:179:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pylsp_black/plugin.py:38: in pylsp_format_document
    return format_document(config, document)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pylsp_black/plugin.py:73: in format_document
    formatted_text = format_text(text=text, config=config, lines=lines)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pylsp_black/plugin.py:114: in format_text
    formatted_text = black.format_file_contents(
src/black/__init__.py:1124: in format_file_contents
    ???
src/black/__init__.py:1089: in check_stability_and_equivalence
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   black.parsing.SourceASTParseError: cannot use --safe with this file; failed to parse source file AST: unexpected indent (<unknown>, line 1)
E   This could be caused by running Black with an older Python version that does not support new syntax used in your source file.

src/black/__init__.py:1638: SourceASTParseError
___________________________________________________________________________ test_pylsp_format_range_syntax_error ____________________________________________________________________________

>   ???

src/black/__init__.py:1636: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   SyntaxError: unexpected indent (<unknown>, line 1)

src/black/parsing.py:162: SyntaxError

During handling of the above exception, another exception occurred:

config = <pylsp.config.config.Config object at 0x7ff7e75433e0>, invalid_document = <pylsp.workspace.Document object at 0x7ff7e74d19b0>

    def test_pylsp_format_range_syntax_error(config, invalid_document):
        range = {"start": {"line": 0, "character": 0}, "end": {"line": 1, "character": 0}}
    
>       result = pylsp_format_range(config, invalid_document, range=range)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/test_plugin.py:253:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pylsp_black/plugin.py:46: in pylsp_format_range
    return format_document(config, document, range)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pylsp_black/plugin.py:73: in format_document
    formatted_text = format_text(text=text, config=config, lines=lines)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pylsp_black/plugin.py:114: in format_text
    formatted_text = black.format_file_contents(
src/black/__init__.py:1124: in format_file_contents
    ???
src/black/__init__.py:1089: in check_stability_and_equivalence
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   black.parsing.SourceASTParseError: cannot use --safe with this file; failed to parse source file AST: unexpected indent (<unknown>, line 1)
E   This could be caused by running Black with an older Python version that does not support new syntax used in your source file.

src/black/__init__.py:1638: SourceASTParseError
===================================================================================== warnings summary ======================================================================================
tests/test_plugin.py:8
  /home/ben/src/forks/python-lsp-black/tests/test_plugin.py:8: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    import pkg_resources

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== short test summary info ==================================================================================
FAILED tests/test_plugin.py::test_pylsp_format_document_syntax_error - black.parsing.SourceASTParseError: cannot use --safe with this file; failed to parse source file AST: unexpected indent (<unknown>, line 1)
FAILED tests/test_plugin.py::test_pylsp_format_range_syntax_error - black.parsing.SourceASTParseError: cannot use --safe with this file; failed to parse source file AST: unexpected indent (<unknown>, line 1)
========================================================================== 2 failed, 19 passed, 1 warning in 0.38s ==========================================================================
```